### PR TITLE
Change the JObject key type from String to JString

### DIFF
--- a/src/data_structures/j_string.rs
+++ b/src/data_structures/j_string.rs
@@ -16,13 +16,14 @@
 // along with json.  If not, see <https://www.gnu.org/licenses/>.
 
 use std::fmt::{Display, Formatter};
+use std::hash::{Hash, Hasher};
 use crate::data_structures::Serialize;
 
 /// A string is a sequence of Unicode code points wrapped with quotation marks (U+0022). All code
 /// points may be placed within the quotation marks except for the code points that must be
 /// escaped: quotation mark (U+0022), reverse solidus (U+005C), and the control characters
 /// U+0000 to U+001F. There are two-character escape sequence representations of some characters.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq)]
 pub struct JString {
     value: String,
 }
@@ -101,6 +102,12 @@ impl Serialize for JString {
 impl PartialEq for JString {
     fn eq(&self, other: &Self) -> bool {
         self.value == other.value
+    }
+}
+
+impl Hash for JString {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.value.hash(state);
     }
 }
 

--- a/src/data_structures/j_value.rs
+++ b/src/data_structures/j_value.rs
@@ -125,7 +125,8 @@ mod test {
         let o2: JValue = JValue::Object(JObject::new());
         assert_eq!(o1, o2);
         let mut obj = JObject::new();
-        obj.insert("key1".to_string(), JValue::Null);
+        let k1 = JString::new("key1").unwrap();
+        obj.insert(k1, JValue::Null);
         let o3: JValue = JValue::Object(obj);
         assert_eq!("{key1 : null,}".to_string(), o3.to_string());
         assert_ne!(o1, o3);
@@ -198,8 +199,11 @@ mod test {
         assert_eq!("{}".to_string(), v.serialize());
 
         let mut obj = JObject::new();
-        obj.insert("key1".to_string(), JValue::Null);
-        obj.insert("key2".to_string(), JValue::Boolean(false));
+        let k1 = JString::new("key1").unwrap();
+        let k2 = JString::new("key2").unwrap();
+        obj.insert(k1, JValue::Null);
+        assert_eq!("{\"key1\":null}".to_string(), obj.serialize());
+        obj.insert(k2, JValue::Boolean(false));
         v = JValue::Object(obj);
         assert!("{\"key1\":null,\"key2\":false}".to_string() == v.serialize()
             || "{\"key2\":false,\"key1\":null}".to_string() == v.serialize());


### PR DESCRIPTION
Implement Hash and Eq for JString so that JString can be used as a key.
Update all the tests accordingly.
Fix #22